### PR TITLE
feat: 파일 관리 기능 구현 및 mapstruct 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	runtimeOnly 'org.postgresql:postgresql'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sb09/hrbank/controller/FileController.java
+++ b/src/main/java/com/sb09/hrbank/controller/FileController.java
@@ -1,0 +1,26 @@
+package com.sb09.hrbank.controller;
+
+import com.sb09.hrbank.service.FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/files")
+@RequiredArgsConstructor
+public class FileController {
+
+  private final FileService fileService;
+
+  @GetMapping("/{id}/download")
+  public ResponseEntity<Resource> download(@PathVariable Long id) {
+    Resource resource = fileService.download(id);
+    return ResponseEntity.ok()
+        .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + resource.getFilename() + "\"")
+        .contentType(MediaType.APPLICATION_OCTET_STREAM)
+        .body(resource);
+  }
+}

--- a/src/main/java/com/sb09/hrbank/entity/FileMeta.java
+++ b/src/main/java/com/sb09/hrbank/entity/FileMeta.java
@@ -1,0 +1,28 @@
+package com.sb09.hrbank.entity;
+
+import com.sb09.hrbank.entity.base.BaseUpdatableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "binary_contents")
+public class FileMeta extends BaseUpdatableEntity {
+
+  @Column(name = "file_name", nullable = false)
+  private String fileName;
+
+  @Column(nullable = false)
+  private Long size;
+
+  @Column(name = "content_type", nullable = false)
+  private String contentType;
+
+  @Column(nullable = false)
+  private String path;
+}

--- a/src/main/java/com/sb09/hrbank/entity/base/BaseEntity.java
+++ b/src/main/java/com/sb09/hrbank/entity/base/BaseEntity.java
@@ -28,3 +28,4 @@ public abstract class BaseEntity {
   @Column(columnDefinition = "timestamp with time zone", updatable = false, nullable = false)
   private Instant createdAt;
 }
+

--- a/src/main/java/com/sb09/hrbank/repository/FileMetaRepository.java
+++ b/src/main/java/com/sb09/hrbank/repository/FileMetaRepository.java
@@ -1,0 +1,9 @@
+package com.sb09.hrbank.repository;
+
+import com.sb09.hrbank.entity.FileMeta;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FileMetaRepository extends JpaRepository<FileMeta, Long> {
+}

--- a/src/main/java/com/sb09/hrbank/service/FileService.java
+++ b/src/main/java/com/sb09/hrbank/service/FileService.java
@@ -1,0 +1,7 @@
+package com.sb09.hrbank.service;
+
+import org.springframework.core.io.Resource;
+
+public interface FileService {
+  Resource download(Long id);
+}

--- a/src/main/java/com/sb09/hrbank/service/basic/BasicFileService.java
+++ b/src/main/java/com/sb09/hrbank/service/basic/BasicFileService.java
@@ -1,0 +1,25 @@
+package com.sb09.hrbank.service.basic;
+
+import com.sb09.hrbank.entity.FileMeta;
+import com.sb09.hrbank.repository.FileMetaRepository;
+import com.sb09.hrbank.service.FileService;
+import com.sb09.hrbank.storage.FileStorage;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BasicFileService implements FileService {
+
+  private final FileMetaRepository repository;
+  private final FileStorage storage;
+
+  @Override
+  public Resource download(Long id) {
+    FileMeta file = repository.findById(id)
+        .orElseThrow(() -> new NoSuchElementException("파일 없음"));
+    return storage.load(file.getPath());
+  }
+}

--- a/src/main/java/com/sb09/hrbank/storage/FileStorage.java
+++ b/src/main/java/com/sb09/hrbank/storage/FileStorage.java
@@ -1,0 +1,13 @@
+package com.sb09.hrbank.storage;
+
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FileStorage {
+
+  public Resource load(String path) {
+    return new FileSystemResource(path);
+  }
+}


### PR DESCRIPTION
## 작업 내용

* 파일 다운로드 Controller 구현 (`FileController`)

  * `/api/files/{id}/download` 엔드포인트 추가
  * `FileService` 연동 및 Resource 반환
* 파일 메타 정보 Entity 구현 (`FileMeta`)

  * 파일명, 크기, MIME 타입, 로컬 경로 관리
* Repository 구현 (`FileMetaRepository`)

  * JPA를 통한 CRUD 지원
* Service 구현 (`BasicFileService`)

  * DB에서 파일 메타 조회 후 `FileStorage`로 파일 로드
  * 존재하지 않는 파일 요청 시 `NoSuchElementException` 발생
* 파일 접근/저장 담당 컴포넌트 구현 (`FileStorage`)

  * 로컬 파일 시스템에서 Resource 반환

## 참고 사항

* 현재 구현은 **다운로드 기능만 지원**
* `FileMeta` Entity와 실제 파일 경로 관리 구조는 향후 **백업/프로필 등 여러 용도 확장 가능**
* 글로벌 예외 처리(`GlobalExceptionHandler`)를 통해 `NoSuchElementException` 발생 시 404 반환

