### PR TITLE
fix: 커서 페이지 size를 실제 응답 건수(dtos.size)로 변경

### DIFF
--- a/src/main/java/com/sb09/hrbank/mapper/CursorPageResponseMapper.java
+++ b/src/main/java/com/sb09/hrbank/mapper/CursorPageResponseMapper.java
@@ -27,7 +27,7 @@ public class CursorPageResponseMapper {
         dtos,
         nextCursor,
         nextIdAfter,
-        slice.getSize(),
+        dtos.size(),
         totalElements,
         slice.hasNext()
     );


### PR DESCRIPTION
커서 매퍼가 받는 값을 실제 값으로 변환했습니다.